### PR TITLE
Don't instantiate the hard-coded array of self-closing tags every hit

### DIFF
--- a/Util.php
+++ b/Util.php
@@ -165,7 +165,12 @@ function html( $tag ) {
 		list( $closing ) = explode( ' ', $tag, 2 );
 	}
 
-	if ( in_array( $closing, array( 'area', 'base', 'basefont', 'br', 'hr', 'input', 'img', 'link', 'meta' ) ) ) {
+	static $SELF_CLOSING_TAGS = null;
+	if($SELF_CLOSING_TAGS === null) {
+		$SELF_CLOSING_TAGS = array( 'area', 'base', 'basefont', 'br', 'hr', 'input', 'img', 'link', 'meta' );
+	}
+	
+	if ( in_array( $closing, $SELF_CLOSING_TAGS ) ) {
 		return "<{$tag} />";
 	}
 


### PR DESCRIPTION
A WordPress theme super-framework I inherited called the html() function thousands of times every page hit. No need to re-create that array each time the function is invoked.
