### PR TITLE
Forms.php > Check that index exists before setting it to var

### DIFF
--- a/Forms.php
+++ b/Forms.php
@@ -193,8 +193,9 @@ class scbForms {
 				foreach ( array_diff( $old_values, $new_values ) as $value )
 					delete_metadata( $meta_type, $object_id, $key, $value );
 			} else {
-				$value = $data[$key];
-
+				$value = '';
+				if(isset($data[$key]))
+					$value = $data[$key];
 				if ( '' === $value )
 					delete_metadata( $meta_type, $object_id, $key );
 				else


### PR DESCRIPTION
Simple fix submitted for your consideration: In debug mode, Forms.php was causing repeated php warnings on line 196 because the index did not exist.  Added a simple check and _poof_ the warning magically disappeared.
