### PR TITLE
Use `wp_kses_data` for validating text fields

### DIFF
--- a/Forms.php
+++ b/Forms.php
@@ -605,7 +605,7 @@ class scbTextField extends scbFormField {
 	 * @return string
 	 */
 	public function validate( $value ) {
-		$sanitize = isset( $this->sanitize ) ? $this->sanitize : 'wp_filter_kses';
+		$sanitize = isset( $this->sanitize ) ? $this->sanitize : 'wp_kses_data';
 
 		return call_user_func( $sanitize, $value, $this );
 	}


### PR DESCRIPTION
Use `wp_kses_data` over `wp_filter_kses` for validating text fields - does the same, but will not slash escape the data.

Issue:
`scbForms::validate_post_data()` strips the slashes from posted values, but in `scbTextField::validate()` they are added back by `wp_filter_kses`.
