### PR TITLE
Display admin message within body

### DIFF
--- a/AdminPage.php
+++ b/AdminPage.php
@@ -213,7 +213,7 @@ abstract class scbAdminPage {
 
 		$this->options->set( $new_data );
 
-		$this->admin_msg();
+		add_action( 'admin_notices', array( $this, 'admin_msg' ) );
 
 		return true;
 	}


### PR DESCRIPTION
In https://github.com/scribu/wp-scb-framework/commit/1a0e52efbf4601b8f89aaad59495ed94b588972e `form_handler()` has been repositioned, runs earlier, and admin message is displayed above opening html tag... 

This pull moves admin message to correct place.
