### PR TITLE
Remove settings_errors() compat check

### DIFF
--- a/AdminPage.php
+++ b/AdminPage.php
@@ -114,8 +114,7 @@ abstract class scbAdminPage {
 
 		if ( isset( $this->option_name ) ) {
 			add_action( 'admin_init', array( $this, 'option_init' ) );
-			if ( function_exists( 'settings_errors' ) )
-				add_action( 'admin_notices', 'settings_errors' );
+			add_action( 'admin_notices', 'settings_errors' );
 		}
 
 		add_action( 'admin_menu', array( $this, 'page_init' ), $this->args['admin_action_priority'] );


### PR DESCRIPTION
Removes WP 2.x compatibility check with `settings_errors()` function which was introduced in WP 3.0

Since Revision 24 `wp-scb-framework` requires WP 3.0
