### PR TITLE
Fix checkbox fields in post metabox

### DIFF
--- a/PostMetabox.php
+++ b/PostMetabox.php
@@ -174,7 +174,7 @@ class scbPostMetabox {
 	private function get_meta( $post_id ) {
 		$meta = get_post_custom( $post_id );
 		foreach ( $meta as $key => $values )
-			$meta[$key] = $meta[$key][0];
+			$meta[ $key ] = maybe_unserialize( $meta[ $key ][0] );
 
 		return $meta;
 	}


### PR DESCRIPTION
Fix checkbox fields, get_post_custom() do not automatically unserialize arrays, props @dikiyforester

Note from [codex](http://codex.wordpress.org/Function_Reference/get_post_custom)

> Note: not only does the function return a multi-dimensional array (ie: always be prepared to deal with an array of arrays, even if expecting array of single values), but it also returns serialized values of any arrays stored as meta values. If you expect that possibly an array may be stored as a metavalue, then be prepared to maybe_unserialize. 

Thanks for looking!
