### PR TITLE
Default values for widget option fields.

### DIFF
--- a/Widget.php
+++ b/Widget.php
@@ -48,8 +48,8 @@ abstract class scbWidget extends WP_Widget {
 	// See scbForms::input()
 	// Allows extra parameter $args['title']
 	protected function input( $args, $formdata = array() ) {
-        if ( $this->number == '__i__' )
-            $formdata = wp_parse_args( $formdata, $this->defaults );
+        if ( empty ( $formdata ) )
+            $formdata = $this->defaults;
 
 		$prefix = array( 'widget-' . $this->id_base, $this->number );
 


### PR DESCRIPTION
Checks if current widget is "prototype" (inside "available widets" panel) and then fills it's option fields with default values.
