### PR TITLE
Fixes unserialize() related warnings

### DIFF
--- a/PostMetabox.php
+++ b/PostMetabox.php
@@ -72,7 +72,7 @@ class scbPostMetabox {
 		$error_fields = array();
 
 		if ( isset( $form_data['_error_data_' . $this->id ] ) ) {
-			$data = unserialize( $form_data['_error_data_' . $this->id ] );
+			$data = maybe_unserialize( $form_data['_error_data_' . $this->id ] );
 
 			$error_fields = $data['fields'];
 			$form_data = $data['data'];


### PR DESCRIPTION
After the last [commit](https://github.com/scribu/wp-scb-framework/commit/19e8854a2569e14c5b69793e4562519547761283), the error handler sometimes displays unserialize() related warnings:
"Warning: unserialize() expects parameter 1 to be string, array given"

Replacing 'unserialize()' with 'maybe_unserialize()' fixes it.
