### PR TITLE
Allow metaboxes to be put in empty columns.

### DIFF
--- a/BoxesPage.php
+++ b/BoxesPage.php
@@ -85,6 +85,10 @@ abstract class scbBoxesPage extends scbAdminPage {
 	padding: 0 !important;
 	margin-bottom: 0 !important;
 }
+.meta-box-sortables {
+	min-height: 100px;
+	width: 100%;
+}
 </style>
 <?php
 	}


### PR DESCRIPTION
When 3 or 4 metabox columns are defined you can only put boxes the first 2 columns, If you remove all meatboxes from a column you then can't put any back into it. This css tweak fixes that.