### PR TITLE
Escape URL's

### DIFF
--- a/AdminPage.php
+++ b/AdminPage.php
@@ -508,7 +508,8 @@ abstract class scbAdminPage {
 	 * @return array
 	 */
 	function _action_link( $links ) {
-		$url = add_query_arg( 'page', $this->args['page_slug'], admin_url( $this->args['parent'] ) );
+		$url = admin_url( $this->args['parent'] );
+		$url = add_query_arg( 'page', $this->args['page_slug'], esc_url( $url ) );
 
 		$links[] = html_link( $url, $this->args['action_link'] );
 

--- a/AdminPage.php
+++ b/AdminPage.php
@@ -573,7 +573,7 @@ abstract class scbAdminPage {
 	 *
 	 * @return array
 	 */
-	function _action_link( $links ) {
+	public function _action_link( $links ) {
 		$url = add_query_arg( 'page', $this->args['page_slug'], admin_url( $this->args['parent'] ) );
 
 		$links[] = html_link( $url, $this->args['action_link'] );

--- a/AdminPage.php
+++ b/AdminPage.php
@@ -574,8 +574,7 @@ abstract class scbAdminPage {
 	 * @return array
 	 */
 	function _action_link( $links ) {
-		$url = admin_url( $this->args['parent'] );
-		$url = add_query_arg( 'page', $this->args['page_slug'], esc_url( $url ) );
+		$url = add_query_arg( 'page', $this->args['page_slug'], admin_url( $this->args['parent'] ) );
 
 		$links[] = html_link( $url, $this->args['action_link'] );
 

--- a/PostMetabox.php
+++ b/PostMetabox.php
@@ -153,7 +153,7 @@ class scbPostMetabox {
 			);
 			update_post_meta( $post_id, '_error_data_' . $this->id, $error_data );
 
-			$location = add_query_arg( 'message', 1, get_edit_post_link( $post_id, 'url' ) );
+			$location = add_query_arg( 'message', 1, esc_url_raw( get_edit_post_link( $post_id, 'url' ) ) );
 			wp_redirect( apply_filters( 'redirect_post_location', $location, $post_id ) );
 			exit;
 		}

--- a/PostMetabox.php
+++ b/PostMetabox.php
@@ -293,7 +293,6 @@ class scbPostMetabox {
 			update_post_meta( $post_id, '_error_data_' . $this->id, $error_data );
 
 			$location = add_query_arg( 'message', 1, get_edit_post_link( $post_id, 'url' ) );
-
 			wp_redirect( esc_url_raw( apply_filters( 'redirect_post_location', $location, $post_id ) ) );
 			exit;
 		}

--- a/PostMetabox.php
+++ b/PostMetabox.php
@@ -292,7 +292,7 @@ class scbPostMetabox {
 			);
 			update_post_meta( $post_id, '_error_data_' . $this->id, $error_data );
 
-			$location = esc_url_raw( add_query_arg( 'message', 1, esc_url_raw( get_edit_post_link( $post_id, 'url' ) ) ) );
+			$location = esc_url_raw( add_query_arg( 'message', 1, get_edit_post_link( $post_id, 'url' ) ) );
 
 			wp_redirect( apply_filters( 'redirect_post_location', $location, $post_id ) );
 			exit;

--- a/PostMetabox.php
+++ b/PostMetabox.php
@@ -292,9 +292,9 @@ class scbPostMetabox {
 			);
 			update_post_meta( $post_id, '_error_data_' . $this->id, $error_data );
 
-			$location = esc_url_raw( add_query_arg( 'message', 1, get_edit_post_link( $post_id, 'url' ) ) );
+			$location = add_query_arg( 'message', 1, get_edit_post_link( $post_id, 'url' ) );
 
-			wp_redirect( apply_filters( 'redirect_post_location', $location, $post_id ) );
+			wp_redirect( esc_url_raw( apply_filters( 'redirect_post_location', $location, $post_id ) ) );
 			exit;
 		}
 

--- a/PostMetabox.php
+++ b/PostMetabox.php
@@ -292,7 +292,8 @@ class scbPostMetabox {
 			);
 			update_post_meta( $post_id, '_error_data_' . $this->id, $error_data );
 
-			$location = add_query_arg( 'message', 1, esc_url_raw( get_edit_post_link( $post_id, 'url' ) ) );
+			$location = esc_url_raw( add_query_arg( 'message', 1, esc_url_raw( get_edit_post_link( $post_id, 'url' ) ) ) );
+
 			wp_redirect( apply_filters( 'redirect_post_location', $location, $post_id ) );
 			exit;
 		}

--- a/Util.php
+++ b/Util.php
@@ -425,7 +425,7 @@ function html_link( $url, $title = '' ) {
 		$title = $url;
 	}
 
-	return html( 'a', array( 'href' => $url ), $title );
+	return html( 'a', array( 'href' => esc_url( $url ) ), $title );
 }
 endif;
 


### PR DESCRIPTION
Hey Cristi!

Simple PR. It escapes some URL's following a known [WP vulnerability](https://make.wordpress.org/plugins/2015/04/20/fixing-add_query_arg-and-remove_query_arg-usage/). It shouldn't affect your code since you pass a URL to `add_query_arg()` but it's always better to have URL's escaped.