### PR TITLE
Don't wrap input in label tag if desc arg is empty

### DIFF
--- a/Forms.php
+++ b/Forms.php
@@ -606,6 +606,10 @@ abstract class scbFormField implements scbFormField_I {
 	 * @return string
 	 */
 	protected static function add_label( $input, $desc, $desc_pos ) {
+		if ( empty( $desc ) ) {
+			return $input;
+		}
+
 		return html( 'label', self::add_desc( $input, $desc, $desc_pos ) ) . "\n";
 	}
 


### PR DESCRIPTION
This allows to avoid unnecessary wrapping and generate label element separately from the input.