### PR TITLE
Fix for PHP notice caused by deprecated screen_icon.

### DIFF
--- a/AdminPage.php
+++ b/AdminPage.php
@@ -186,7 +186,6 @@ abstract class scbAdminPage {
 	 */
 	protected function page_header() {
 		echo "<div class='wrap'>\n";
-		screen_icon( $this->args['screen_icon'] );
 		echo html( 'h2', $this->args['page_title'] );
 	}
 
@@ -510,7 +509,6 @@ abstract class scbAdminPage {
 			'toplevel'              => '',
 			'position'              => null,
 			'icon_url'              => '',
-			'screen_icon'           => '',
 			'parent'                => 'options-general.php',
 			'capability'            => 'manage_options',
 			'menu_title'            => $this->args['page_title'],
@@ -581,4 +579,3 @@ abstract class scbAdminPage {
 		return $links;
 	}
 }
-


### PR DESCRIPTION
The inclusion of the wp-scb-framework in bj-lazy-load plugin throws a PHP notice in the plugin's settings page because screen_icon deprecated  function.