### PR TITLE
Fix for PHP notice caused by deprecated hook 'contextual_help'

### DIFF
--- a/AdminPage.php
+++ b/AdminPage.php
@@ -135,7 +135,7 @@ abstract class scbAdminPage {
 		}
 
 		add_action( 'admin_menu', array( $this, 'page_init' ), $this->args['admin_action_priority'] );
-		add_filter( 'contextual_help', array( $this, '_contextual_help' ), 10, 2 );
+		add_action( 'current_screen', array( $this, '_contextual_help' ) );
 
 		if ( $file ) {
 			$this->file = $file;
@@ -534,23 +534,17 @@ abstract class scbAdminPage {
 	/**
 	 * Adds contextual help.
 	 *
-	 * @param string        $help
-	 * @param string|object $screen
+	 * @param WP_Screen $screen
 	 *
 	 * @return string
 	 */
-	public function _contextual_help( $help, $screen ) {
-		if ( is_object( $screen ) ) {
-			$screen = $screen->id;
-		}
+	public function _contextual_help( $screen ) {
 
 		$actual_help = $this->page_help();
 
-		if ( $screen == $this->pagehook && $actual_help ) {
-			return $actual_help;
+		if ( $screen->id == $this->pagehook && $actual_help ) {
+			$screen::add_old_compat_help( $screen, $actual_help );
 		}
-
-		return $help;
 	}
 
 	/**

--- a/AdminPage.php
+++ b/AdminPage.php
@@ -135,7 +135,7 @@ abstract class scbAdminPage {
 		}
 
 		add_action( 'admin_menu', array( $this, 'page_init' ), $this->args['admin_action_priority'] );
-		add_action( 'current_screen', array( $this, '_contextual_help' ) );
+		add_action( 'current_screen', array( $this, '_contextual_help_compat' ) );
 
 		if ( $file ) {
 			$this->file = $file;
@@ -534,13 +534,33 @@ abstract class scbAdminPage {
 	/**
 	 * Adds contextual help.
 	 *
-	 * @param WP_Screen $screen
+	 * @param string        $help
+	 * @param string|object $screen
 	 *
 	 * @return string
 	 */
-	public function _contextual_help( $screen ) {
+	public function _contextual_help( $help, $screen ) {
+		if ( is_object( $screen ) ) {
+			$screen = $screen->id;
+		}
 
 		$actual_help = $this->page_help();
+
+		if ( $screen == $this->pagehook && $actual_help ) {
+			return $actual_help;
+		}
+
+		return $help;
+	}
+
+	/**
+	 * Sets the old string-based contextual help for the screen for backward compatibility.
+	 *
+	 * @param WP_Screen $screen
+	 */
+	public function _contextual_help_compat( $screen ) {
+
+		$actual_help = $this->_contextual_help( '', $screen );
 
 		if ( $screen->id == $this->pagehook && $actual_help ) {
 			$screen::add_old_compat_help( $screen, $actual_help );


### PR DESCRIPTION
Removed filter from the 'contextual_help' hook.
Added action to 'current_screen' hook.
Set the old string-based contextual help for the screen for backward compatibility.