### PR TITLE
Removed deprecated procedure for contextual help hook.

### DIFF
--- a/AdminPage.php
+++ b/AdminPage.php
@@ -135,7 +135,6 @@ abstract class scbAdminPage {
 		}
 
 		add_action( 'admin_menu', array( $this, 'page_init' ), $this->args['admin_action_priority'] );
-		add_filter( 'contextual_help', array( $this, '_contextual_help' ), 10, 2 );
 
 		if ( $file ) {
 			$this->file = $file;
@@ -171,13 +170,6 @@ abstract class scbAdminPage {
 	 * @return void
 	 */
 	public function page_head() { }
-
-	/**
-	 * This is where the contextual help goes.
-	 *
-	 * @return string
-	 */
-	protected function page_help() { }
 
 	/**
 	 * A generic page header.
@@ -529,28 +521,6 @@ abstract class scbAdminPage {
 		if ( empty( $this->args['nonce'] ) ) {
 			$this->nonce = $this->args['page_slug'];
 		}
-	}
-
-	/**
-	 * Adds contextual help.
-	 *
-	 * @param string        $help
-	 * @param string|object $screen
-	 *
-	 * @return string
-	 */
-	public function _contextual_help( $help, $screen ) {
-		if ( is_object( $screen ) ) {
-			$screen = $screen->id;
-		}
-
-		$actual_help = $this->page_help();
-
-		if ( $screen == $this->pagehook && $actual_help ) {
-			return $actual_help;
-		}
-
-		return $help;
 	}
 
 	/**


### PR DESCRIPTION
Hello,

I found this issue in the Posts 2 Posts plugin on wordpress.org: https://wordpress.org/support/topic/deprecated-filter-contextual_help/ and it happens to be a problem that I also experienced.

I followed the code and I got to this framework. I removed the code that is deprecated (and causing the error), I thought that it would be better to simply remove it now to avoid showing errors for the plugins that depends on it before getting to an actual solution for it in a later version.

Let me know if it is possible to move this forward or if is not possible to move forward this solution for any reason.

Thanks in advance!