### PR TITLE
Fix deprecated required parameters followed by optional parameters.

### DIFF
--- a/Cron.php
+++ b/Cron.php
@@ -21,7 +21,7 @@ class scbCron {
 	 *
 	 * @return void
 	 */
-	public function __construct( $file = false, $args ) {
+	public function __construct( $file = false, $args = [] ) {
 
 		// Set time & schedule
 		if ( isset( $args['time'] ) ) {

--- a/Forms.php
+++ b/Forms.php
@@ -62,7 +62,7 @@ class scbForms {
 	 *
 	 * @return string
 	 */
-	public static function form( $inputs, $formdata = null, $nonce ) {
+	public static function form( $inputs, $formdata = null, $nonce = '' ) {
 		$output = '';
 		foreach ( $inputs as $input ) {
 			$output .= self::input( $input, $formdata );


### PR DESCRIPTION
Fixes these two errors:

```
Deprecated: Required parameter $nonce follows optional parameter $formdata in /wp-content/plugins/posts-to-posts/vendor/scribu/scb-framework/Forms.php on line 65

Deprecated: Required parameter $args follows optional parameter $file in /wp-content/plugins/posts-to-posts/vendor/scribu/scb-framework/Cron.php on line 24
```